### PR TITLE
Align API contracts and refresh UI

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [
     'eslint:recommended',
-    '@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended',
   ],
   root: true,
   env: {

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -31,10 +31,7 @@ export class AuthController {
         role
       });
 
-      res.status(201).json({
-        message: 'Utilisateur créé avec succès',
-        data: result
-      });
+      res.status(201).json(result);
     } catch (error) {
       logger.error('Erreur dans register controller:', error);
 
@@ -69,10 +66,7 @@ export class AuthController {
 
       const result = await AuthService.login({ email, password });
 
-      res.json({
-        message: 'Connexion réussie',
-        data: result
-      });
+      res.json(result);
     } catch (error) {
       logger.error('Erreur dans login controller:', error);
 
@@ -98,10 +92,7 @@ export class AuthController {
 
       const profile = await AuthService.getProfile(req.user.id);
 
-      res.json({
-        message: 'Profil récupéré avec succès',
-        data: profile
-      });
+      res.json(profile);
     } catch (error) {
       logger.error('Erreur dans getMe controller:', error);
 
@@ -139,10 +130,7 @@ export class AuthController {
         email
       });
 
-      res.json({
-        message: 'Profil mis à jour avec succès',
-        data: updatedUser
-      });
+      res.json(updatedUser);
     } catch (error) {
       logger.error('Erreur dans updateProfile controller:', error);
 

--- a/backend/src/controllers/equipmentController.ts
+++ b/backend/src/controllers/equipmentController.ts
@@ -33,10 +33,7 @@ export class EquipmentController {
         notes
       }, req.user.id);
 
-      res.status(201).json({
-        message: 'Équipement créé avec succès',
-        data: equipment
-      });
+      res.status(201).json(equipment);
     } catch (error) {
       logger.error('Erreur dans createEquipment controller:', error);
 
@@ -72,10 +69,7 @@ export class EquipmentController {
 
       const result = await EquipmentService.getEquipments(filters, options);
 
-      res.json({
-        message: 'Équipements récupérés avec succès',
-        data: result
-      });
+      res.json(result);
     } catch (error) {
       logger.error('Erreur dans getEquipments controller:', error);
       res.status(500).json({ error: 'Erreur serveur lors de la récupération des équipements' });
@@ -94,10 +88,7 @@ export class EquipmentController {
 
       const equipment = await EquipmentService.getEquipmentById(id);
 
-      res.json({
-        message: 'Équipement récupéré avec succès',
-        data: equipment
-      });
+      res.json(equipment);
     } catch (error) {
       logger.error('Erreur dans getEquipmentById controller:', error);
 
@@ -145,10 +136,7 @@ export class EquipmentController {
         notes
       }, req.user.id);
 
-      res.json({
-        message: 'Équipement mis à jour avec succès',
-        data: equipment
-      });
+      res.json(equipment);
     } catch (error) {
       logger.error('Erreur dans updateEquipment controller:', error);
 
@@ -181,10 +169,7 @@ export class EquipmentController {
 
       const result = await EquipmentService.deleteEquipment(id, req.user.id);
 
-      res.json({
-        message: 'Équipement supprimé avec succès',
-        data: result
-      });
+      res.json(result);
     } catch (error) {
       logger.error('Erreur dans deleteEquipment controller:', error);
 
@@ -227,12 +212,9 @@ export class EquipmentController {
 
       const { tagId } = req.body;
 
-      const nfcTag = await EquipmentService.assignNfcTag(id, tagId, req.user.id);
+      const equipment = await EquipmentService.assignNfcTag(id, tagId, req.user.id);
 
-      res.json({
-        message: 'Tag NFC assigné avec succès',
-        data: nfcTag
-      });
+      res.json(equipment);
     } catch (error) {
       logger.error('Erreur dans assignNfcTag controller:', error);
 
@@ -265,12 +247,9 @@ export class EquipmentController {
         return;
       }
 
-      const result = await EquipmentService.removeNfcTag(id, req.user.id);
+      const equipment = await EquipmentService.removeNfcTag(id, req.user.id);
 
-      res.json({
-        message: 'Tag NFC retiré avec succès',
-        data: result
-      });
+      res.json(equipment);
     } catch (error) {
       logger.error('Erreur dans removeNfcTag controller:', error);
 
@@ -291,10 +270,7 @@ export class EquipmentController {
     try {
       const statistics = await EquipmentService.getStatistics();
 
-      res.json({
-        message: 'Statistiques récupérées avec succès',
-        data: statistics
-      });
+      res.json(statistics);
     } catch (error) {
       logger.error('Erreur dans getStatistics controller:', error);
       res.status(500).json({ error: 'Erreur serveur lors de la récupération des statistiques' });

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -29,6 +29,8 @@ export interface AuthResponse {
     lastName: string;
     role: UserRole;
     isActive: boolean;
+    createdAt: Date;
+    updatedAt: Date;
   };
   token: string;
 }
@@ -72,7 +74,9 @@ export class AuthService {
           firstName: true,
           lastName: true,
           role: true,
-          isActive: true
+          isActive: true,
+          createdAt: true,
+          updatedAt: true
         }
       });
 
@@ -136,7 +140,9 @@ export class AuthService {
           firstName: user.firstName,
           lastName: user.lastName,
           role: user.role,
-          isActive: user.isActive
+          isActive: user.isActive,
+          createdAt: user.createdAt,
+          updatedAt: user.updatedAt
         },
         token
       };
@@ -213,6 +219,7 @@ export class AuthService {
           lastName: true,
           role: true,
           isActive: true,
+          createdAt: true,
           updatedAt: true
         }
       });

--- a/frontend/src/components/common/Card.tsx
+++ b/frontend/src/components/common/Card.tsx
@@ -4,12 +4,14 @@ interface CardProps {
   children: React.ReactNode;
   className?: string;
   title?: string;
+  contentClassName?: string;
 }
 
 export const Card: React.FC<CardProps> = ({
   children,
   className = '',
   title,
+  contentClassName = '',
 }) => {
   return (
     <div className={`bg-white shadow rounded-lg ${className}`}>
@@ -18,7 +20,7 @@ export const Card: React.FC<CardProps> = ({
           <h3 className="text-lg font-medium text-gray-900">{title}</h3>
         </div>
       )}
-      <div className="px-6 py-4">
+      <div className={`px-6 py-4 ${contentClassName}`}>
         {children}
       </div>
     </div>

--- a/frontend/src/components/forms/LoginForm.tsx
+++ b/frontend/src/components/forms/LoginForm.tsx
@@ -67,9 +67,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <h2 className="text-2xl font-bold text-gray-900 mb-6">Connexion</h2>
-
+    <form onSubmit={handleSubmit} className="space-y-5">
       {error && (
         <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
           {error}
@@ -109,12 +107,12 @@ export const LoginForm: React.FC<LoginFormProps> = ({
       </Button>
 
       {onSwitchToRegister && (
-        <p className="text-center text-sm text-gray-600">
+        <p className="text-center text-sm text-gray-500">
           Pas encore de compte ?{' '}
           <button
             type="button"
             onClick={onSwitchToRegister}
-            className="text-blue-600 hover:text-blue-500 font-medium"
+            className="font-semibold text-blue-600 hover:text-blue-500"
           >
             S'inscrire
           </button>

--- a/frontend/src/components/forms/RegisterForm.tsx
+++ b/frontend/src/components/forms/RegisterForm.tsx
@@ -97,9 +97,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <h2 className="text-2xl font-bold text-gray-900 mb-6">Inscription</h2>
-
+    <form onSubmit={handleSubmit} className="space-y-5">
       {error && (
         <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
           {error}
@@ -174,12 +172,12 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
       </Button>
 
       {onSwitchToLogin && (
-        <p className="text-center text-sm text-gray-600">
+        <p className="text-center text-sm text-gray-500">
           Déjà un compte ?{' '}
           <button
             type="button"
             onClick={onSwitchToLogin}
-            className="text-blue-600 hover:text-blue-500 font-medium"
+            className="font-semibold text-blue-600 hover:text-blue-500"
           >
             Se connecter
           </button>

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -67,12 +67,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       setIsLoading(true);
       setError(null);
-      await authService.register(userData);
-      // Après inscription, connecter automatiquement
-      await login({
-        email: userData.email,
-        password: userData.password,
-      });
+      const response = await authService.register(userData);
+      setUser(response.user);
     } catch (err) {
       const apiError = err as ApiError;
       setError(apiError.message);

--- a/frontend/src/hooks/useEquipments.ts
+++ b/frontend/src/hooks/useEquipments.ts
@@ -28,9 +28,9 @@ export const useEquipments = (initialFilters?: EquipmentFilters) => {
       const response = await equipmentService.getEquipments(filtersToUse);
 
       setEquipments(response.equipments);
-      setTotal(response.total);
-      setTotalPages(response.totalPages);
-      setCurrentPage(response.page);
+      setTotal(response.pagination.totalItems);
+      setTotalPages(response.pagination.totalPages);
+      setCurrentPage(response.pagination.currentPage);
     } catch (err) {
       const apiError = err as ApiError;
       setError(apiError.message);
@@ -87,10 +87,10 @@ export const useEquipments = (initialFilters?: EquipmentFilters) => {
     }
   };
 
-  const assignNfcTag = async (equipmentId: string, nfcTagUid: string): Promise<void> => {
+  const assignNfcTag = async (equipmentId: string, tagId: string): Promise<void> => {
     try {
       setError(null);
-      const updatedEquipment = await equipmentService.assignNfcTag(equipmentId, nfcTagUid);
+      const updatedEquipment = await equipmentService.assignNfcTag(equipmentId, tagId);
       setEquipments(prev => prev.map(eq => eq.id === equipmentId ? updatedEquipment : eq));
     } catch (err) {
       const apiError = err as ApiError;

--- a/frontend/src/pages/auth/AuthPage.tsx
+++ b/frontend/src/pages/auth/AuthPage.tsx
@@ -19,38 +19,88 @@ export const AuthPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-      <div className="sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="flex justify-center">
-          <h1 className="text-3xl font-bold text-gray-900">
-            Gestionnaire NFC
-          </h1>
+    <div className="relative min-h-screen bg-slate-950">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_#38bdf8_0%,_transparent_55%)] opacity-60" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_#0f172a_0%,_transparent_60%)] opacity-70" />
+
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-6xl flex-col-reverse items-center gap-12 px-6 py-12 lg:flex-row lg:items-center lg:justify-between">
+        <div className="w-full max-w-md lg:max-w-lg">
+          <Card className="backdrop-blur-sm bg-white/95" contentClassName="px-8 py-10">
+            <div className="mb-6 text-center">
+              <h1 className="text-2xl font-semibold text-gray-900">Gestionnaire NFC</h1>
+              <p className="mt-2 text-sm text-gray-500">
+                Connectez-vous pour suivre, prêter et maintenir vos équipements en quelques clics.
+              </p>
+            </div>
+
+            <div className="flex gap-2 rounded-full bg-gray-100 p-1 text-xs font-medium text-gray-500">
+              <button
+                type="button"
+                onClick={() => setActiveTab('login')}
+                className={`flex-1 rounded-full px-3 py-1 transition ${
+                  activeTab === 'login' ? 'bg-white text-gray-900 shadow-sm' : ''
+                }`}
+              >
+                Connexion
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('register')}
+                className={`flex-1 rounded-full px-3 py-1 transition ${
+                  activeTab === 'register' ? 'bg-white text-gray-900 shadow-sm' : ''
+                }`}
+              >
+                Inscription
+              </button>
+            </div>
+
+            <div className="mt-6">
+              {activeTab === 'login' ? (
+                <LoginForm
+                  onSuccess={handleAuthSuccess}
+                  onSwitchToRegister={() => setActiveTab('register')}
+                />
+              ) : (
+                <RegisterForm
+                  onSuccess={handleAuthSuccess}
+                  onSwitchToLogin={() => setActiveTab('login')}
+                />
+              )}
+            </div>
+          </Card>
+
+          <p className="mt-6 text-center text-xs text-slate-300">
+            © 2024 Gestionnaire NFC — Prototype interne
+          </p>
         </div>
-        <p className="mt-2 text-center text-sm text-gray-600">
-          Gestion d'équipements avec technologie NFC
-        </p>
-      </div>
 
-      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <Card className="py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          {activeTab === 'login' ? (
-            <LoginForm
-              onSuccess={handleAuthSuccess}
-              onSwitchToRegister={() => setActiveTab('register')}
-            />
-          ) : (
-            <RegisterForm
-              onSuccess={handleAuthSuccess}
-              onSwitchToLogin={() => setActiveTab('login')}
-            />
-          )}
-        </Card>
-      </div>
+        <div className="w-full max-w-xl text-center lg:text-left">
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-white/70">
+            Prototype interactif
+          </div>
+          <h2 className="mt-6 text-4xl font-semibold text-white sm:text-5xl">
+            Centralisez le suivi de vos équipements NFC.
+          </h2>
+          <p className="mt-4 max-w-lg text-sm text-slate-200/90">
+            Ce POC offre une vision rapide des mouvements de parc, des maintenances en cours et des tags associés. Une base solide pour préparer la mise en production.
+          </p>
 
-      <div className="mt-6 text-center">
-        <p className="text-xs text-gray-500">
-          © 2024 Gestionnaire NFC - Prototype de démonstration
-        </p>
+          <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {[
+              'Affectation rapide des tags NFC',
+              'Suivi des statuts en temps réel',
+              'Historique des interventions',
+              'Interface claire et responsive',
+            ].map((item) => (
+              <div key={item} className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-left">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-400/80 text-slate-900">
+                  ✓
+                </span>
+                <span className="text-sm text-slate-100/90">{item}</span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -25,28 +25,24 @@ export const DashboardPage: React.FC = () => {
 
   const statusCards = [
     {
-      title: 'Total Équipements',
-      value: statistics?.total || 0,
-      color: 'bg-blue-600',
-      icon: '📦',
+      title: 'En service',
+      value: statistics?.byStatus?.IN_SERVICE ?? 0,
+      accent: 'from-emerald-500/80 to-emerald-400/60',
     },
     {
-      title: 'En Service',
-      value: statistics?.inService || 0,
-      color: 'bg-green-600',
-      icon: '✅',
+      title: 'Hors service',
+      value: statistics?.byStatus?.OUT_OF_SERVICE ?? 0,
+      accent: 'from-rose-500/80 to-rose-400/60',
     },
     {
-      title: 'Hors Service',
-      value: statistics?.outOfService || 0,
-      color: 'bg-red-600',
-      icon: '❌',
+      title: 'En maintenance',
+      value: statistics?.byStatus?.MAINTENANCE ?? 0,
+      accent: 'from-amber-500/80 to-amber-400/60',
     },
     {
-      title: 'Maintenance',
-      value: statistics?.maintenance || 0,
-      color: 'bg-yellow-600',
-      icon: '🔧',
+      title: 'Prêtés',
+      value: statistics?.byStatus?.LOANED ?? 0,
+      accent: 'from-indigo-500/80 to-indigo-400/60',
     },
   ];
 
@@ -54,8 +50,11 @@ export const DashboardPage: React.FC = () => {
     <div className="space-y-6">
       {/* Header */}
       <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold text-gray-900">Tableau de bord</h1>
-        <div className="flex space-x-3">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-blue-600">Synthèse</p>
+          <h1 className="text-3xl font-semibold text-gray-900">Tableau de bord</h1>
+        </div>
+        <div className="flex flex-wrap gap-3">
           <Link to="/equipments">
             <Button variant="secondary">
               Voir tous les équipements
@@ -70,17 +69,24 @@ export const DashboardPage: React.FC = () => {
       </div>
 
       {/* Statistiques principales */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card className="bg-gradient-to-br from-blue-600 to-cyan-500 text-white shadow-lg">
+          <div className="space-y-2">
+            <p className="text-sm uppercase tracking-wide text-white/70">Total équipements</p>
+            <p className="text-4xl font-semibold">{statistics?.totalEquipments ?? 0}</p>
+            <p className="text-sm text-white/70">
+              Parc suivi via les puces NFC
+            </p>
+          </div>
+        </Card>
         {statusCards.map((card) => (
-          <Card key={card.title} className="text-center">
-            <div className="flex items-center justify-center space-x-3">
-              <div className={`p-3 rounded-full ${card.color} text-white`}>
-                <span className="text-2xl">{card.icon}</span>
-              </div>
+          <Card key={card.title} className="relative overflow-hidden">
+            <div className="flex items-center justify-between">
               <div>
-                <p className="text-2xl font-bold text-gray-900">{card.value}</p>
-                <p className="text-sm text-gray-600">{card.title}</p>
+                <p className="text-sm font-medium text-gray-500">{card.title}</p>
+                <p className="mt-2 text-3xl font-semibold text-gray-900">{card.value}</p>
               </div>
+              <div className={`h-16 w-16 rounded-full bg-gradient-to-br ${card.accent} opacity-70 blur-sm`} />
             </div>
           </Card>
         ))}
@@ -89,12 +95,15 @@ export const DashboardPage: React.FC = () => {
       {/* Répartition par catégorie */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card title="Répartition par catégorie">
-          {statistics?.byCategory ? (
-            <div className="space-y-3">
-              {Object.entries(statistics.byCategory).map(([category, count]) => (
-                <div key={category} className="flex justify-between items-center">
-                  <span className="text-sm font-medium text-gray-700">{category}</span>
-                  <span className="text-sm text-gray-900 bg-gray-100 px-2 py-1 rounded">
+          {statistics?.byCategory?.length ? (
+            <div className="space-y-4">
+              {statistics.byCategory.map(({ category, count }) => (
+                <div key={category} className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">{category}</p>
+                    <p className="text-xs text-gray-500">{count} équipement{count > 1 ? 's' : ''}</p>
+                  </div>
+                  <span className="rounded-full bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700">
                     {count}
                   </span>
                 </div>
@@ -105,78 +114,59 @@ export const DashboardPage: React.FC = () => {
           )}
         </Card>
 
-        <Card title="Répartition par localisation">
-          {statistics?.byLocation ? (
-            <div className="space-y-3">
-              {Object.entries(statistics.byLocation).map(([location, count]) => (
-                <div key={location} className="flex justify-between items-center">
-                  <span className="text-sm font-medium text-gray-700">{location}</span>
-                  <span className="text-sm text-gray-900 bg-gray-100 px-2 py-1 rounded">
-                    {count}
+        <Card title="Activité récente">
+          {statistics?.recentActivity?.length ? (
+            <div className="space-y-4">
+              {statistics.recentActivity.map((event) => (
+                <div key={event.id} className="flex items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <p className="text-sm font-semibold text-gray-900">{event.equipment.name}</p>
+                    <p className="text-xs text-gray-500">{event.description ?? 'Mise à jour'}</p>
+                  </div>
+                  <span className="text-xs uppercase tracking-wide text-gray-400">
+                    {new Date(event.createdAt).toLocaleDateString('fr-FR', {
+                      day: '2-digit',
+                      month: 'short',
+                    })}
                   </span>
                 </div>
               ))}
             </div>
           ) : (
-            <p className="text-gray-500">Aucune donnée disponible</p>
+            <p className="text-gray-500">Aucune activité récente</p>
           )}
         </Card>
       </div>
 
       {/* Actions rapides */}
       <Card title="Actions rapides">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <Link
-            to="/equipments?status=OUT_OF_SERVICE"
-            className="block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            <div className="flex items-center space-x-3">
-              <span className="text-2xl">⚠️</span>
-              <div>
-                <h3 className="font-medium text-gray-900">Équipements défaillants</h3>
-                <p className="text-sm text-gray-600">Voir les équipements hors service</p>
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            to="/equipments?status=MAINTENANCE"
-            className="block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            <div className="flex items-center space-x-3">
-              <span className="text-2xl">🔧</span>
-              <div>
-                <h3 className="font-medium text-gray-900">Maintenance</h3>
-                <p className="text-sm text-gray-600">Équipements en maintenance</p>
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            to="/equipments/export"
-            className="block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            <div className="flex items-center space-x-3">
-              <span className="text-2xl">📊</span>
-              <div>
-                <h3 className="font-medium text-gray-900">Export CSV</h3>
-                <p className="text-sm text-gray-600">Télécharger les données</p>
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            to="/nfc"
-            className="block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            <div className="flex items-center space-x-3">
-              <span className="text-2xl">📱</span>
-              <div>
-                <h3 className="font-medium text-gray-900">Scanner NFC</h3>
-                <p className="text-sm text-gray-600">Lire et écrire des tags NFC</p>
-              </div>
-            </div>
-          </Link>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+          {[{
+            title: 'Équipements hors service',
+            description: 'Identifier les équipements à remplacer',
+            to: '/equipments?status=OUT_OF_SERVICE',
+          }, {
+            title: 'Suivi maintenance',
+            description: 'Planifier les interventions à venir',
+            to: '/equipments?status=MAINTENANCE',
+          }, {
+            title: 'Exporter le parc',
+            description: 'Télécharger le fichier CSV consolidé',
+            to: '/equipments/export',
+          }, {
+            title: 'Console NFC',
+            description: 'Scanner et affecter de nouveaux tags',
+            to: '/nfc',
+          }].map((action) => (
+            <Link
+              key={action.to}
+              to={action.to}
+              className="group rounded-xl border border-gray-200 bg-white/60 p-4 transition hover:border-blue-200 hover:bg-blue-50/40"
+            >
+              <h3 className="text-sm font-semibold text-gray-900">{action.title}</h3>
+              <p className="mt-2 text-sm text-gray-600 group-hover:text-gray-700">{action.description}</p>
+            </Link>
+          ))}
         </div>
       </Card>
     </div>

--- a/frontend/src/pages/equipments/EquipmentListPage.tsx
+++ b/frontend/src/pages/equipments/EquipmentListPage.tsx
@@ -4,18 +4,18 @@ import { useEquipments } from '../../hooks/useEquipments';
 import { Card } from '../../components/common/Card';
 import { Button } from '../../components/common/Button';
 
-const statusLabels = {
+const statusLabels: Record<string, string> = {
   IN_SERVICE: 'En service',
   OUT_OF_SERVICE: 'Hors service',
   MAINTENANCE: 'Maintenance',
-  RETIRED: 'Retiré',
+  LOANED: 'En prêt',
 };
 
-const statusColors = {
-  IN_SERVICE: 'bg-green-100 text-green-800',
-  OUT_OF_SERVICE: 'bg-red-100 text-red-800',
-  MAINTENANCE: 'bg-yellow-100 text-yellow-800',
-  RETIRED: 'bg-gray-100 text-gray-800',
+const statusClasses: Record<string, string> = {
+  IN_SERVICE: 'bg-emerald-50 text-emerald-700 ring-emerald-600/20',
+  OUT_OF_SERVICE: 'bg-rose-50 text-rose-700 ring-rose-600/20',
+  MAINTENANCE: 'bg-amber-50 text-amber-700 ring-amber-600/20',
+  LOANED: 'bg-indigo-50 text-indigo-700 ring-indigo-600/20',
 };
 
 export const EquipmentListPage: React.FC = () => {
@@ -40,39 +40,44 @@ export const EquipmentListPage: React.FC = () => {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Équipements</h1>
-          <p className="text-gray-600">{total} équipement(s) au total</p>
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-1">
+          <p className="text-sm font-medium uppercase tracking-wide text-blue-600">Inventaire</p>
+          <h1 className="text-3xl font-semibold text-gray-900">Équipements</h1>
+          <p className="text-sm text-gray-600">
+            {total} équipement{total > 1 ? 's' : ''} suivis dans le parc
+          </p>
         </div>
-        <Link to="/equipments/new">
+        <Link to="/equipments/new" className="md:self-start">
           <Button variant="primary">
-            Ajouter équipement
+            Ajouter un équipement
           </Button>
         </Link>
       </div>
 
       {/* Liste des équipements */}
-      <Card>
+      <Card className="overflow-hidden" contentClassName="p-0">
         {equipments.length === 0 ? (
-          <div className="text-center py-12">
-            <span className="text-6xl mb-4 block">📦</span>
-            <h3 className="text-lg font-medium text-gray-900 mb-2">
-              Aucun équipement
-            </h3>
-            <p className="text-gray-600 mb-4">
-              Commencez par ajouter votre premier équipement.
-            </p>
+          <div className="flex flex-col items-center justify-center gap-3 py-16">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-dashed border-gray-300">
+              <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-500 to-cyan-500 opacity-70" />
+            </div>
+            <div className="text-center">
+              <h3 className="text-lg font-semibold text-gray-900">Aucun équipement pour le moment</h3>
+              <p className="mt-1 text-sm text-gray-600">
+                Ajoutez votre premier équipement pour lancer le suivi NFC.
+              </p>
+            </div>
             <Link to="/equipments/new">
               <Button variant="primary">
-                Ajouter équipement
+                Ajouter un équipement
               </Button>
             </Link>
           </div>
         ) : (
-          <div className="overflow-hidden">
+          <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50/80">
                 <tr>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Nom
@@ -96,34 +101,46 @@ export const EquipmentListPage: React.FC = () => {
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
                 {equipments.map((equipment) => (
-                  <tr key={equipment.id} className="hover:bg-gray-50">
+                  <tr key={equipment.id} className="hover:bg-gray-50/70">
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <div>
-                        <div className="text-sm font-medium text-gray-900">
+                      <div className="flex flex-col gap-1">
+                        <span className="text-sm font-semibold text-gray-900">
                           {equipment.name}
-                        </div>
+                        </span>
                         {equipment.serialNumber && (
-                          <div className="text-sm text-gray-500">
-                            S/N: {equipment.serialNumber}
-                          </div>
+                          <span className="text-xs uppercase tracking-wide text-gray-500">
+                            S/N&nbsp;{equipment.serialNumber}
+                          </span>
                         )}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {equipment.category}
+                      <span className="inline-flex rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200">
+                        {equipment.category}
+                      </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${statusColors[equipment.status]}`}>
-                        {statusLabels[equipment.status]}
+                      <span
+                        className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${
+                          statusClasses[equipment.status] || 'bg-gray-50 text-gray-700 ring-gray-200'
+                        }`}
+                      >
+                        <span className="inline-block h-2.5 w-2.5 rounded-full bg-current opacity-75" />
+                        {statusLabels[equipment.status] ?? equipment.status}
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {equipment.location}
+                      {equipment.location ? (
+                        <span className="font-medium text-gray-800">{equipment.location}</span>
+                      ) : (
+                        <span className="text-gray-400">Non renseigné</span>
+                      )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      {equipment.nfcTagId ? (
-                        <span className="inline-flex items-center px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full">
-                          📱 Assigné
+                      {equipment.tag ? (
+                        <span className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700 ring-1 ring-inset ring-blue-200">
+                          <span className="inline-block h-2 w-2 rounded-full bg-blue-400" />
+                          {equipment.tag.tagId}
                         </span>
                       ) : (
                         <span className="text-gray-400">Non assigné</span>
@@ -132,15 +149,9 @@ export const EquipmentListPage: React.FC = () => {
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                       <Link
                         to={`/equipments/${equipment.id}`}
-                        className="text-blue-600 hover:text-blue-900 mr-4"
+                        className="text-blue-600 transition hover:text-blue-800"
                       >
                         Détails
-                      </Link>
-                      <Link
-                        to={`/equipments/${equipment.id}/edit`}
-                        className="text-gray-600 hover:text-gray-900"
-                      >
-                        Modifier
                       </Link>
                     </td>
                   </tr>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -47,6 +47,14 @@ class ApiClient {
     this.token = localStorage.getItem('authToken');
   }
 
+  private extractResponse<T>(payload: any): T {
+    if (payload && typeof payload === 'object' && 'data' in payload && payload.data !== undefined) {
+      return payload.data as T;
+    }
+
+    return payload as T;
+  }
+
   setToken(token: string): void {
     this.token = token;
     localStorage.setItem('authToken', token);
@@ -68,22 +76,22 @@ class ApiClient {
   // Méthodes HTTP génériques
   async get<T>(url: string, params?: Record<string, any>): Promise<T> {
     const response: AxiosResponse<T> = await this.client.get(url, { params });
-    return response.data;
+    return this.extractResponse<T>(response.data);
   }
 
   async post<T>(url: string, data?: any): Promise<T> {
     const response: AxiosResponse<T> = await this.client.post(url, data);
-    return response.data;
+    return this.extractResponse<T>(response.data);
   }
 
   async put<T>(url: string, data?: any): Promise<T> {
     const response: AxiosResponse<T> = await this.client.put(url, data);
-    return response.data;
+    return this.extractResponse<T>(response.data);
   }
 
   async delete<T>(url: string): Promise<T> {
     const response: AxiosResponse<T> = await this.client.delete(url);
-    return response.data;
+    return this.extractResponse<T>(response.data);
   }
 }
 

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -13,8 +13,10 @@ export class AuthService {
     return response;
   }
 
-  async register(userData: RegisterRequest): Promise<User> {
-    return await apiClient.post<User>('/auth/register', userData);
+  async register(userData: RegisterRequest): Promise<LoginResponse> {
+    const response = await apiClient.post<LoginResponse>('/auth/register', userData);
+    apiClient.setToken(response.token);
+    return response;
   }
 
   async getCurrentUser(): Promise<User> {

--- a/frontend/src/services/equipmentService.ts
+++ b/frontend/src/services/equipmentService.ts
@@ -45,9 +45,9 @@ export class EquipmentService {
     return response.data;
   }
 
-  async assignNfcTag(equipmentId: string, nfcTagUid: string): Promise<Equipment> {
+  async assignNfcTag(equipmentId: string, tagId: string): Promise<Equipment> {
     return await apiClient.post<Equipment>(`/equipments/${equipmentId}/nfc-tag`, {
-      nfcTagUid,
+      tagId,
     });
   }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -5,32 +5,43 @@ export interface User {
   firstName: string;
   lastName: string;
   role: 'ADMIN' | 'USER';
+  isActive: boolean;
   createdAt: string;
   updatedAt: string;
 }
+
+export type EquipmentStatus = 'IN_SERVICE' | 'OUT_OF_SERVICE' | 'MAINTENANCE' | 'LOANED';
 
 export interface Equipment {
   id: string;
   name: string;
   category: string;
-  status: 'IN_SERVICE' | 'OUT_OF_SERVICE' | 'MAINTENANCE' | 'RETIRED';
-  location: string;
+  status: EquipmentStatus;
+  location?: string;
   description?: string;
   serialNumber?: string;
   purchaseDate?: string;
   warrantyEndDate?: string;
-  nfcTagId?: string;
   createdAt: string;
   updatedAt: string;
   createdBy: string;
-  nfcTag?: NfcTag;
-  events?: EquipmentEvent[];
+  notes?: string;
+  tag?: NfcTag | null;
+  creator?: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+  _count?: {
+    events: number;
+  };
 }
 
 export interface NfcTag {
   id: string;
-  uid: string;
-  equipmentId?: string;
+  tagId: string;
+  equipmentId?: string | null;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -39,7 +50,7 @@ export interface NfcTag {
 export interface EquipmentEvent {
   id: string;
   equipmentId: string;
-  type: 'CREATED' | 'UPDATED' | 'STATUS_CHANGED' | 'LOCATION_CHANGED' | 'NFC_TAG_ASSIGNED' | 'NFC_TAG_REMOVED';
+  type: 'LOAN' | 'RETURN' | 'MAINTENANCE_START' | 'MAINTENANCE_END' | 'STATUS_CHANGE' | 'TAG_ASSIGNED' | 'TAG_REMOVED';
   description: string;
   metadata?: Record<string, any>;
   createdAt: string;
@@ -48,13 +59,17 @@ export interface EquipmentEvent {
 }
 
 export interface EquipmentStatistics {
-  total: number;
-  inService: number;
-  outOfService: number;
-  maintenance: number;
-  retired: number;
-  byCategory: Record<string, number>;
-  byLocation: Record<string, number>;
+  totalEquipments: number;
+  byStatus: Record<string, number>;
+  byCategory: Array<{ category: string; count: number }>;
+  recentActivity: Array<{
+    id: string;
+    type: EquipmentEvent['type'];
+    description: string | null;
+    createdAt: string;
+    equipment: { id: string; name: string };
+    user: { id: string; firstName: string; lastName: string };
+  }>;
 }
 
 // Request/Response types
@@ -90,10 +105,14 @@ export interface UpdateEquipmentRequest extends Partial<CreateEquipmentRequest> 
 
 export interface EquipmentListResponse {
   equipments: Equipment[];
-  total: number;
-  page: number;
-  limit: number;
-  totalPages: number;
+  pagination: {
+    currentPage: number;
+    itemsPerPage: number;
+    totalItems: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+  };
 }
 
 export interface EquipmentFilters {


### PR DESCRIPTION
## Summary
- return authentication responses with top-level token and complete user fields and stop nesting API payloads behind `data`
- update equipment services to surface updated equipment details when assigning tags and expose consistent pagination/statistics
- refresh the frontend data models, API client, and screens (auth, dashboard, list) to match the API and present a more polished interface

## Testing
- `npm run lint` *(backend, fails: existing lint rule definitions and legacy any usage)*
- `npm run lint` *(frontend, fails: legacy lint debt in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d10b43a7308326b6b0178e62fd93cd